### PR TITLE
Fix missing topics by disabling Jekyll

### DIFF
--- a/.nojekyll
+++ b/.nojekyll
@@ -1,0 +1,1 @@
+# Disable Jekyll so YAML assets like posts.yml are served


### PR DESCRIPTION
## Summary
- Disable Jekyll processing so YAML files like `assets/posts.yml` are served

## Testing
- `python -m py_compile server.py`
- `node --check assets/script.js`


------
https://chatgpt.com/codex/tasks/task_e_68aaad2949548333b133d05921b5232c